### PR TITLE
1. 마감순 정렬 기능 추가(+마감기한이 없는 특수 case 처리)

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -15,7 +15,7 @@
               </deviceKey>
             </Target>
           </runningDeviceTargetSelectedWithDropDown>
-          <timeTargetWasSelectedWithDropDown value="2024-06-07T16:33:42.715182300Z" />
+          <timeTargetWasSelectedWithDropDown value="2024-06-09T01:50:55.019025100Z" />
         </State>
       </entry>
     </value>

--- a/app/src/main/java/com/example/amap_teamproject/menu/Activity.java
+++ b/app/src/main/java/com/example/amap_teamproject/menu/Activity.java
@@ -168,5 +168,6 @@ public class Activity implements Parcelable {
     public void setTimestamp(Timestamp timestamp) {
         this.timestamp = timestamp;
     }
+
 }
 

--- a/app/src/main/java/com/example/amap_teamproject/menu/ActivityAdapter.java
+++ b/app/src/main/java/com/example/amap_teamproject/menu/ActivityAdapter.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
 import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -13,6 +14,7 @@ import androidx.recyclerview.widget.RecyclerView;
 
 import com.bumptech.glide.Glide;
 import com.example.amap_teamproject.R;
+//import com.example.amap_teamproject.TeamPageActivity; // 추가
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.firestore.DocumentReference;
@@ -67,6 +69,14 @@ public class ActivityAdapter extends RecyclerView.Adapter<ActivityAdapter.ViewHo
         setDdayStatus(holder.ddayStatus, activity.getSubPeriod());
         holder.hitCount.setText("조회수: " + activity.getHits()); // 조회수 설정
         holder.likeCount.setText("찜: " + activity.getLikes()); // 좋아요 수 설정
+/*
+        holder.teamRecruitButton.setOnClickListener(v -> {
+            Intent intent = new Intent(holder.itemView.getContext(), TeamPageActivity.class);
+            intent.putExtra("type", "activity");
+            intent.putExtra("documentId", activity.getTitle());
+            holder.itemView.getContext().startActivity(intent);
+        });
+        */
     }
 
     @Override
@@ -82,6 +92,7 @@ public class ActivityAdapter extends RecyclerView.Adapter<ActivityAdapter.ViewHo
         TextView likeCount; // 좋아요 수를 표시하기 위한 TextView 추가
         ImageView imageView;
         ImageButton favButton;
+        Button teamRecruitButton; // 팀원 모집 버튼 추가
 
         ViewHolder(View view) {
             super(view);
@@ -92,6 +103,7 @@ public class ActivityAdapter extends RecyclerView.Adapter<ActivityAdapter.ViewHo
             likeCount = view.findViewById(R.id.activity_like_count); // 추가된 부분
             imageView = view.findViewById(R.id.activity_image);
             favButton = view.findViewById(R.id.action_button);
+            teamRecruitButton = view.findViewById(R.id.team_recruit_button); // 팀원 모집 버튼 추가
         }
     }
 

--- a/app/src/main/java/com/example/amap_teamproject/menu/EventAdapter.java
+++ b/app/src/main/java/com/example/amap_teamproject/menu/EventAdapter.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
 import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -17,6 +18,7 @@ import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.FirebaseFirestore;
+//import com.example.amap_teamproject.TeamPageActivity; // 추가
 import com.google.firebase.firestore.Query;
 import com.google.firebase.firestore.QueryDocumentSnapshot;
 
@@ -66,6 +68,13 @@ public class EventAdapter extends RecyclerView.Adapter<EventAdapter.ViewHolder> 
         initializeButton(event, holder.favButton, holder.likeCount);
         setDdayStatus(holder.ddayStatus, event.getSubPeriod());
         holder.hitCount.setText("조회수: " + event.getHits()); // 조회수 설정
+
+        /*holder.teamRecruitButton.setOnClickListener(v -> {
+            Intent intent = new Intent(holder.itemView.getContext(), TeamPageActivity.class);
+            intent.putExtra("eventTitle", event.getTitle());
+            intent.putExtra("eventType", "contest");
+            holder.itemView.getContext().startActivity(intent);
+        });*/
     }
 
     @Override
@@ -81,6 +90,7 @@ public class EventAdapter extends RecyclerView.Adapter<EventAdapter.ViewHolder> 
         TextView likeCount; // 좋아요 수를 표시하기 위한 TextView 추가
         ImageView imageView;
         ImageButton favButton;
+        Button teamRecruitButton; // 팀원 모집 버튼
 
         ViewHolder(View view) {
             super(view);
@@ -91,6 +101,7 @@ public class EventAdapter extends RecyclerView.Adapter<EventAdapter.ViewHolder> 
             likeCount = view.findViewById(R.id.event_like_count); // 추가된 부분
             imageView = view.findViewById(R.id.event_image);
             favButton = view.findViewById(R.id.action_button);
+            teamRecruitButton = view.findViewById(R.id.team_recruit_button); // 추가된 부분
         }
     }
 
@@ -220,4 +231,3 @@ public class EventAdapter extends RecyclerView.Adapter<EventAdapter.ViewHolder> 
         });
     }
 }
-

--- a/app/src/main/res/layout/fragment_item_activity.xml
+++ b/app/src/main/res/layout/fragment_item_activity.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -9,47 +8,41 @@
     android:layout_marginBottom="5dp"
     android:background="@drawable/background_item">
 
-    <!-- 텍스트 정보를 담는 레이아웃 -->
     <LinearLayout
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:orientation="vertical">
 
-        <!-- 제목 -->
         <TextView
             android:id="@+id/activity_title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textStyle="bold"
             android:textSize="16sp"
-            tools:text="활동 제목" />
+            android:maxLines="1"
+            android:ellipsize="end" />
 
-        <!-- 조직 이름과 D-day 간의 공백 -->
         <TextView
             android:layout_width="wrap_content"
-            android:layout_height="8dp" />
+            android:layout_height="8dp" /> <!-- 제목과 주최기관 간의 공백 -->
 
-        <!-- 조직 이름 -->
         <TextView
             android:id="@+id/activity_organization"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="14sp"
-            tools:text="주최 기관" />
+            android:textSize="14sp" />
 
-        <!-- 조직 이름과 D-day 간의 공백 -->
         <TextView
             android:layout_width="wrap_content"
-            android:layout_height="4dp" />
+            android:layout_height="4dp" /> <!-- 주최기관과 D-day 상태 간의 공백 -->
 
-        <!-- D-day -->
         <TextView
             android:id="@+id/activity_dday_status"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textSize="12sp"
-            android:textColor="@android:color/darker_gray" />
+            android:textColor="@android:color/darker_gray" /> <!-- 텍스트 색상을 회색으로 설정 -->
 
         <LinearLayout
             android:layout_width="wrap_content"
@@ -63,10 +56,9 @@
                 android:textSize="12sp"
                 android:textColor="@android:color/darker_gray" />
 
-            <!-- 조회수와 찜 수 사이의 공백 -->
             <TextView
                 android:layout_width="8dp"
-                android:layout_height="wrap_content" />
+                android:layout_height="wrap_content" /> <!-- 조회수와 좋아요 수 간의 공백 -->
 
             <TextView
                 android:id="@+id/activity_like_count"
@@ -74,11 +66,10 @@
                 android:layout_height="wrap_content"
                 android:textSize="12sp"
                 android:textColor="@android:color/darker_gray" />
-        </LinearLayout>
 
+        </LinearLayout>
     </LinearLayout>
 
-    <!-- 이미지 -->
     <ImageView
         android:id="@+id/activity_image"
         android:layout_width="100dp"
@@ -87,16 +78,29 @@
         android:layout_marginStart="8dp"
         android:contentDescription="활동 이미지"
         android:scaleType="fitCenter"
-        android:adjustViewBounds="true"
-        tools:src="@drawable/ic_launcher_foreground" />
+        android:adjustViewBounds="true" />
 
-    <android.widget.ImageButton
-        android:id="@+id/action_button"
-        android:layout_width="50dp"
-        android:layout_height="50dp"
-        android:src="@drawable/empty_heart"
-        android:background="@android:color/transparent"
-        android:padding="0dp"
-        android:scaleType="centerInside" />
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:gravity="center">
 
+        <Button
+            android:id="@+id/team_recruit_button"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:text="팀원 모집"
+            android:textSize="12sp"
+            android:background="@drawable/button_background" />
+
+        <ImageButton
+            android:id="@+id/action_button"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:src="@drawable/empty_heart"
+            android:background="@android:color/transparent"
+            android:padding="0dp"
+            android:scaleType="centerInside" />
+    </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_item_event.xml
+++ b/app/src/main/res/layout/fragment_item_event.xml
@@ -19,7 +19,9 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:textStyle="bold"
-            android:textSize="16sp" />
+            android:textSize="16sp"
+            android:maxLines="1"
+            android:ellipsize="end" />
 
         <TextView
             android:layout_width="wrap_content"
@@ -74,16 +76,31 @@
         android:layout_height="100dp"
         android:layout_gravity="center_vertical"
         android:layout_marginStart="8dp"
-        android:contentDescription="그냥 출력값"
+        android:contentDescription="공모전 이미지"
         android:scaleType="fitCenter"
         android:adjustViewBounds="true" />
 
-    <android.widget.ImageButton
-        android:id="@+id/action_button"
-        android:layout_width="50dp"
-        android:layout_height="50dp"
-        android:src="@drawable/empty_heart"
-        android:background="@android:color/transparent"
-        android:padding="0dp"
-        android:scaleType="centerInside"/>
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:gravity="center">
+
+        <Button
+            android:id="@+id/team_recruit_button"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:text="팀원 모집"
+            android:textSize="12sp"
+            android:background="@drawable/button_background" />
+
+        <ImageButton
+            android:id="@+id/action_button"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:src="@drawable/empty_heart"
+            android:background="@android:color/transparent"
+            android:padding="0dp"
+            android:scaleType="centerInside" />
+    </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -114,6 +114,7 @@
     <string-array name="sort_options">
         <item>등록순</item>
         <item>최신순</item>
+        <item>마감순</item>
         <item>조회수 높은 순</item>
         <item>조회수 낮은 순</item>
         <item>좋아요 많은 순</item>


### PR DESCRIPTION
2. 모든 정렬들은 '마감됨'의 경우 정렬 기준에 관계없이 제일 아래에 배치
3. 팀원모집/좋아요 버튼 재구성(현재 TeamPageActivity에 Intent 하는 부분은 주석처리 되어있음)
4. 정렬 bar에 있는 텍스트도 등록순으로 default 처리되도록 했음
5. 이제 다른 필터링 버튼으로 전환하더라도 사용자가 고른 정렬 기능을 즉시 반영하도록 수정
6. 제목이 너무 길면 각 공모전/대외활동의 버튼 크기가 일정하지 않으므로, 제목이 긴 경우 일정 부분은 ... 처리